### PR TITLE
Improve documentation on passing arguments via CLI

### DIFF
--- a/docs/docs/02-examples/01-cli.md
+++ b/docs/docs/02-examples/01-cli.md
@@ -284,3 +284,63 @@ Hopefully you've found this guide helpful. From here, you have several options:
 
 - You can checkout out some of our other guides available in this section of the docs
 - You can dive deeper into the options available when [writing script](/tools/gpt-file-reference)
+
+## Passing Arguments via CLI
+
+When running a tool directly with the CLI, you can pass arguments to the tool using JSON-formatted input. This allows you to specify key-value pairs that the tool can use to perform its tasks. Here's how you can do it:
+
+### Basic Usage
+
+To pass a single argument to a tool, you can use the following syntax:
+
+```
+gptscript tool.gpt '{"argName":"argValue"}'
+```
+
+For example, if you have a tool that requires a `url` argument, you can run it like this:
+
+```
+gptscript tool.gpt '{"url":"https://example.com"}'
+```
+
+### Passing Multiple Arguments
+
+You can also pass multiple arguments to a tool by including them in the JSON object:
+
+```
+gptscript tool.gpt '{"arg1":"value1", "arg2":"value2"}'
+```
+
+### Nested JSON Objects
+
+For more complex scenarios, you can pass nested JSON objects as arguments:
+
+```
+gptscript tool.gpt '{"config":{"option1":"value1", "option2":"value2"}}'
+```
+
+This is particularly useful for tools that require configuration objects or when you need to pass a list of values.
+
+### Examples
+
+Here are some examples of passing arguments via CLI:
+
+- Passing a simple key-value pair:
+
+```
+gptscript echo.gpt '{"message":"Hello, World!"}'
+```
+
+- Passing multiple arguments:
+
+```
+gptscript process-data.gpt '{"inputFile":"data.csv", "outputFile":"result.json"}'
+```
+
+- Passing a nested JSON object:
+
+```
+gptscript configure-system.gpt '{"settings":{"theme":"dark", "notifications":false}}'
+```
+
+By using JSON-formatted input, you can easily pass any type of argument to your tools, making them more flexible and powerful.

--- a/docs/docs/02-examples/05-workflow.md
+++ b/docs/docs/02-examples/05-workflow.md
@@ -187,3 +187,11 @@ Use #GPTScript with #Python to build the front end of this AI-powered YouTube ge
 - [Tutorial on building an AI-powered YouTube title and thumbnail generator (Part 1)](https://buff.ly/4aGJYCD): Covers setting up the front end with Flask, modifying the script, and creating templates for the front page and result page.
 - [Tutorial on building an AI-powered YouTube title and thumbnail generator (Part 2)](https://buff.ly/49MSK1k): Covers the installation and setup of GPTScript, creating a basic script, handling command-line arguments, generating a YouTube title, and generating thumbnails using DALL-E 3.
 ```
+
+To demonstrate how to pass arguments to a tool via the CLI, consider the following example:
+
+```
+gptscript workflow-demo.gpt '{"url":"https://x.com/acornlabs/status/1798063732394000559"}'
+```
+
+In this example, we're running the `workflow-demo.gpt` script and passing a JSON object as an argument. The JSON object contains a key `url` with the value of the tweet URL we want to summarize. This is how you can dynamically pass arguments to your GPTScript tools via the CLI.

--- a/docs/docs/03-tools/02-authoring.md
+++ b/docs/docs/03-tools/02-authoring.md
@@ -77,7 +77,6 @@ GPTScript can execute any binary that you ask it to. However, it can also manage
 | `Node.js`  | [Vision](https://github.com/gptscript-ai/gpt4-v-vision) - Analyze and interpret images                         |
 | `Golang`   | [Search](https://github.com/gptscript-ai/search) - Use various providers to search the internet                |
 
-
 ### Automatic Documentation
 
 Each GPTScript tool is self-documented using the `tool.gpt` file. You can automatically generate documentation for your tools by visiting `tools.gptscript.ai/<github repo url>`. This documentation site allows others to easily search and explore the tools that have been created. 
@@ -85,3 +84,63 @@ Each GPTScript tool is self-documented using the `tool.gpt` file. You can automa
 You can add more information about how to use your tool by adding an `examples` directory to your repository and adding a collection of `.gpt` files that demonstrate how to use your tool. These examples will be automatically included in the documentation.
 
 For more information and to explore existing tools, visit [tools.gptscript.ai](https://tools.gptscript.ai).
+
+## Passing Arguments via CLI
+
+When running a tool directly with the CLI, you can pass arguments to the tool using JSON-formatted input. This allows you to specify key-value pairs that the tool can use to perform its tasks. Here's how you can do it:
+
+### Basic Usage
+
+To pass a single argument to a tool, you can use the following syntax:
+
+```
+gptscript tool.gpt '{"argName":"argValue"}'
+```
+
+For example, if you have a tool that requires a `url` argument, you can run it like this:
+
+```
+gptscript tool.gpt '{"url":"https://example.com"}'
+```
+
+### Passing Multiple Arguments
+
+You can also pass multiple arguments to a tool by including them in the JSON object:
+
+```
+gptscript tool.gpt '{"arg1":"value1", "arg2":"value2"}'
+```
+
+### Nested JSON Objects
+
+For more complex scenarios, you can pass nested JSON objects as arguments:
+
+```
+gptscript tool.gpt '{"config":{"option1":"value1", "option2":"value2"}}'
+```
+
+This is particularly useful for tools that require configuration objects or when you need to pass a list of values.
+
+### Examples
+
+Here are some examples of passing arguments via CLI:
+
+- Passing a simple key-value pair:
+
+```
+gptscript echo.gpt '{"message":"Hello, World!"}'
+```
+
+- Passing multiple arguments:
+
+```
+gptscript process-data.gpt '{"inputFile":"data.csv", "outputFile":"result.json"}'
+```
+
+- Passing a nested JSON object:
+
+```
+gptscript configure-system.gpt '{"settings":{"theme":"dark", "notifications":false}}'
+```
+
+By using JSON-formatted input, you can easily pass any type of argument to your tools, making them more flexible and powerful.


### PR DESCRIPTION
Related to #2

Updates documentation to clearly explain how to pass arguments to tools via the CLI, enhancing usability and flexibility for users.

- **Adds a new section "Passing Arguments via CLI" in `docs/docs/03-tools/02-authoring.md`**: This section provides detailed instructions and examples on passing JSON-formatted arguments to tools via the CLI, including basic usage, passing multiple arguments, and handling nested JSON objects.
- **Integrates CLI argument passing examples into `docs/docs/02-examples/05-workflow.md` and `docs/docs/02-examples/01-cli.md`**: Demonstrates practical application of CLI argument passing in different contexts, such as automated workflows and local CLI interactions, with clear examples for users to follow.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/botchagalupeai/gptscript/issues/2?shareId=05962095-44bf-497d-b5cd-3c011cdcdedd).